### PR TITLE
adding health_check_type

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -34,6 +34,7 @@ locals {
     protect_from_scale_in         = false                           # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
     iam_role_id                   = "${local.default_iam_role_id}"  # Use the specified IAM role if set.
     suspended_processes           = ""                              # A comma delimited string of processes to to suspend. i.e. AZRebalance,HealthCheck,ReplaceUnhealthy
+    health_check_type             = "EC2"                           # "EC2" or "ELB". Controls how health checking is done.
   }
 
   workers_group_defaults = "${merge(local.workers_group_defaults_defaults, var.workers_group_defaults)}"

--- a/workers.tf
+++ b/workers.tf
@@ -7,6 +7,7 @@ resource "aws_autoscaling_group" "workers" {
   vpc_zone_identifier   = ["${split(",", coalesce(lookup(var.worker_groups[count.index], "subnets", ""), local.workers_group_defaults["subnets"]))}"]
   protect_from_scale_in = "${lookup(var.worker_groups[count.index], "protect_from_scale_in", local.workers_group_defaults["protect_from_scale_in"])}"
   suspended_processes   = ["${compact(split(",", coalesce(lookup(var.worker_groups[count.index], "suspended_processes", ""), local.workers_group_defaults["suspended_processes"])))}"]
+  health_check_type     = "${lookup(var.worker_groups[count.index], "health_check_type", local.workers_group_defaults["health_check_type"])}"
   count                 = "${var.worker_group_count}"
 
   tags = ["${concat(


### PR DESCRIPTION
# PR o'clock

## Description

- Adding ability to specify ASG `health_check_type`, either "ELB" or "EC2" (default). 

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
